### PR TITLE
tag bugs fixed

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -38,20 +38,25 @@ router.get('/', csrfProtection,asyncHandler( async (req, res, next) => {
 router.post("/search/tags",csrfProtection,asyncHandler(async (req, res) => {
     const result = req.body;
     let id = [];
-    let questions = [];
+    let unfilteredQuestions = [];
     const vals = Object.values(result);
     for (let i = 0; i < vals.length - 1; i++) {
       id.push(parseInt(vals[i]));
     }
-    
+  
     let tags = await Tag.findAll({
       where: { id: [...id] },
       include: Question,
     });
     for (let i = 0; i < tags.length; i++) {
-      questions.push(tags[i].Questions[0]);
-    }
-    // console.log(tags[0].Questions[0])
+      if(tags[i].Questions){
+        unfilteredQuestions.push(tags[i].Questions[0]);
+      }else{return}
+    };
+    const questions=unfilteredQuestions.filter(question=>{
+      if (question){return question}
+    })
+    
     res.render("search-result", { questions ,csrfToken:req.csrfToken(),});
   })
 );

--- a/views/index.pug
+++ b/views/index.pug
@@ -47,17 +47,17 @@ block content
       button(id=`edit-${question.id}` type='button' class= 'edit-button') Edit
       button(id=`delete-${question.id}` type='button' class= 'delete-button') Delete
       button(id=`answer-${question.id}` type='button' class= 'answer-button') Answers
-    div 
-      form(method='post' action='/search/tags')
-            div 
-                h2 Please Select From These Available Topics 
-            
-            each tag in Tags 
-            
-                input(type='checkbox' name=tag.name value=tag.id)
-                label= tag.name
-            
-            div 
-                button(type='submit') Search Tags
-                input(type='hidden' name='_csrf' value=csrfToken)
-      
+  div 
+    form(method='post' action='/search/tags')
+          div 
+              h2 Please Select From These Available Topics 
+          
+          each tag in Tags 
+          
+              input(type='checkbox' name=tag.name value=tag.id)
+              label= tag.name
+          
+          div 
+              button(type='submit') Search Tags
+              input(type='hidden' name='_csrf' value=csrfToken)
+    

--- a/views/search-result.pug
+++ b/views/search-result.pug
@@ -5,5 +5,10 @@ block content
       fieldset
         a(href=`/answers/${question.id}`) 
             p= question.content
-      div
+    div
+        a(href='/') Return to Home
+  else 
+    fieldset 
+      p No results found!
+    div
         a(href='/') Return to Home


### PR DESCRIPTION
ok so on top of there being a tag search option after every question. another bug was that when you click on a tag that doesnt have any questions the whole thing explodes.  Took me awhile but I got rid of that bug.  

if you select just a bunch of tags with no questions you should just be able to click return to home

if you select some tags with questions and then some more tags with no questions, it should just show you the questions that are available and not throw a huge error (that's what it was doing)